### PR TITLE
Fix for #1766

### DIFF
--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -66,7 +66,7 @@ class VoyagerServiceProvider extends ServiceProvider
             $this->registerAppCommands();
         }
         
-        if (env('DB_CONNECTION') === 'mysql'){
+        if (env('DB_CONNECTION') === 'mysql') {
             Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'blob');
         }
     }


### PR DESCRIPTION
This fixes an issue that occurs when rolling back migrations containing enum-type columns on MySQL connections.
I'm not sure I've added it the right place, or if there are better ways of checking the current DB connection type. I'm also not sure if this could have any side effects.